### PR TITLE
Add sitewide library loader

### DIFF
--- a/docs/GeometryofLinearGroups/Algebraic/Tools/discretenessCertificate.html
+++ b/docs/GeometryofLinearGroups/Algebraic/Tools/discretenessCertificate.html
@@ -83,9 +83,7 @@
       margin-bottom: 8px;
     }
   </style>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/11.11.2/math.min.js"></script>
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-  <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+  <script src="../../../assets/js/common-libs.js"></script>
 </head>
 <body>
   <button id="backButton" style="position: absolute; top: 10px; left: 10px; z-index: 11;">Back</button>

--- a/docs/GeometryofLinearGroups/Algebraic/Tools/numberRings.html
+++ b/docs/GeometryofLinearGroups/Algebraic/Tools/numberRings.html
@@ -4,11 +4,8 @@
   <link rel="stylesheet" href="../../../assets/css/backBtn.css">
   <meta charset="UTF-8">
   <title>Number Ring Tool</title>
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-  <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
-  <script src="https://sagecell.sagemath.org/static/embedded_sagecell.js"></script>
+  <script src="../../../assets/js/common-libs.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mathquill/0.10.1/mathquill.min.css" />
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathquill/0.10.1/mathquill.min.js"></script>
   <style>
     body {
       background-color: #121212;

--- a/docs/GeometryofLinearGroups/Algebraic/Tools/numberRingsMatrices.html
+++ b/docs/GeometryofLinearGroups/Algebraic/Tools/numberRingsMatrices.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title>Minimal Ring A via SageMathCell</title>
-  <!-- 1) load the SageCell widget library -->
-  <script src="https://sagecell.sagemath.org/static/embedded_sagecell.js"></script>
+  <!-- Load shared libraries -->
+  <script src="../../../assets/js/common-libs.js"></script>
 </head>
 <body style="font-family: sans-serif; margin: 2em;">
   <h1>Compute the Minimal Ring A for ⟨S⟩⊆PGL₂(A)</h1>

--- a/docs/GeometryofLinearGroups/Algebraic/Tools/polynomialMatrices.html
+++ b/docs/GeometryofLinearGroups/Algebraic/Tools/polynomialMatrices.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>Polynomial Matrices over ZZ</title>
-    <script src="https://sagecell.sagemath.org/static/embedded_sagecell.js"></script>
+    <script src="../../../assets/js/common-libs.js"></script>
 </head>
 <body>
 <h1>Polynomial Matrices over ZZ</h1>

--- a/docs/GeometryofLinearGroups/Arithmetic/Tools/GPS.html
+++ b/docs/GeometryofLinearGroups/Arithmetic/Tools/GPS.html
@@ -67,9 +67,8 @@
     <p>&copy; 2025 Nic Brody / UCSC Geometry Tools</p>
   </footer>
 
-  <!-- External scripts -->
-  <script src="https://cdn.jsdelivr.net/npm/mathjs@11.3.0/lib/browser/math.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r132/three.min.js"></script>
+  <!-- Load shared libraries -->
+  <script src="../../../assets/js/common-libs.js"></script>
   <!-- Tool-specific script -->
   <script src="../js/GPS.js"></script>
 </body>

--- a/docs/GeometryofLinearGroups/Arithmetic/Tools/modular.html
+++ b/docs/GeometryofLinearGroups/Arithmetic/Tools/modular.html
@@ -9,9 +9,7 @@
       }
     };
   </script>
-  <script id="MathJax-script" async
-    src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
-  </script>
+  <script src="../../../assets/js/common-libs.js"></script>
   <style>
     /* Hide number input arrows */
     input[type=number]::-webkit-outer-spin-button,

--- a/docs/GeometryofLinearGroups/Arithmetic/Tools/orthogonal.html
+++ b/docs/GeometryofLinearGroups/Arithmetic/Tools/orthogonal.html
@@ -3,9 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>O[1,1,1,-7] Coxeter Polyhedron</title>
-  <script src="https://cdn.jsdelivr.net/npm/mathjs@13.3.2/dist/math.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r153/three.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/three@0.153.0/examples/js/controls/OrbitControls.js"></script>
+  <script src="../../../assets/js/common-libs.js"></script>
   <style>
     body { margin: 0; overflow: hidden; }
     #angleTable {

--- a/docs/GeometryofLinearGroups/Geometric/Euclidean/Tools/2deuc2.html
+++ b/docs/GeometryofLinearGroups/Geometric/Euclidean/Tools/2deuc2.html
@@ -108,9 +108,7 @@
       z-index: 12;
     }
   </style>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/11.11.2/math.min.js"></script>
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-  <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+  <script src="../../../assets/js/common-libs.js"></script>
 </head>
 <body>
   <button id="backButton" style="position: absolute; top: 10px; left: 10px; z-index: 11;">Back</button>

--- a/docs/GeometryofLinearGroups/Geometric/Euclidean/Tools/euclideandirichlet.html
+++ b/docs/GeometryofLinearGroups/Geometric/Euclidean/Tools/euclideandirichlet.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8" />
   <title>Dirichlet Domain in ℝ² (Column‐Vector Generators + LaTeX)</title>
 
-  <!-- 1) Load math.js for numeric/vector computations -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/11.3.0/math.min.js"></script>
+  <!-- Load shared libraries -->
+  <script src="../../../assets/js/common-libs.js"></script>
 
   <!-- 2) Load MathJax for LaTeX rendering -->
   <script>
@@ -17,12 +17,6 @@
       svg: { fontCache: 'global' }
     };
   </script>
-  <script
-    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-svg.min.js"
-    integrity="sha512-BsjDqsh258W6b62uNdrGLrcVZ/0Nwh7BHVhgagIDpZPfDeJLpvGJDKdwQqTTI6Ij0mXG+dwPxR8/TXPsAvUl5w=="
-    crossorigin="anonymous"
-    referrerpolicy="no-referrer"
-  ></script>
 
   <style>
     body {

--- a/docs/GeometryofLinearGroups/Geometric/Kleinian/Tools/dirchlet2.html
+++ b/docs/GeometryofLinearGroups/Geometric/Kleinian/Tools/dirchlet2.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <title>Dirichlet Domain Visualization</title>
 
-  <!-- Math.js for complex arithmetic -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/11.3.2/math.min.js"></script>
+  <!-- Load shared libraries -->
+  <script src="../../../assets/js/common-libs.js"></script>
 
   <style>
     body {

--- a/docs/GeometryofLinearGroups/Geometric/Kleinian/Tools/dirichlet.html
+++ b/docs/GeometryofLinearGroups/Geometric/Kleinian/Tools/dirichlet.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <title>Dirichlet Domain Visualization</title>
 
-  <!-- Math.js for complex arithmetic -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/11.3.2/math.min.js"></script>
+  <!-- Load shared libraries -->
+  <script src="../../../assets/js/common-libs.js"></script>
 
   <style>
     body {

--- a/docs/GeometryofLinearGroups/Geometric/Kleinian/Tools/limitsets.html
+++ b/docs/GeometryofLinearGroups/Geometric/Kleinian/Tools/limitsets.html
@@ -108,9 +108,7 @@
       z-index: 12;
     }
   </style>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/11.11.2/math.min.js"></script>
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-  <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+  <script src="../../../assets/js/common-libs.js"></script>
 </head>
 <body>
   <button id="backButton" style="position: absolute; top: 10px; left: 10px; z-index: 11;">Back</button>

--- a/docs/GeometryofLinearGroups/Geometric/padicGroups/Tools/trees.html
+++ b/docs/GeometryofLinearGroups/Geometric/padicGroups/Tools/trees.html
@@ -83,9 +83,7 @@
       margin-bottom: 8px;
     }
   </style>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/11.11.2/math.min.js"></script>
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-  <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+  <script src="../../../assets/js/common-libs.js"></script>
 </head>
 <body>
   <button id="backButton" style="position: absolute; top: 10px; left: 10px; z-index: 11;">Back</button>

--- a/docs/GeometryofLinearGroups/index.html
+++ b/docs/GeometryofLinearGroups/index.html
@@ -65,7 +65,7 @@
       }
     };
   </script>
-  <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js" async></script>
+    <script src="../assets/js/common-libs.js"></script>
 </head>
 <body>
 

--- a/docs/assets/js/common-libs.js
+++ b/docs/assets/js/common-libs.js
@@ -1,0 +1,23 @@
+(function() {
+  const libs = [
+    "https://polyfill.io/v3/polyfill.min.js?features=es6",
+    "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js",
+    "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js",
+    "https://cdn.jsdelivr.net/npm/mathjs@11.3.0/lib/browser/math.js",
+    "https://cdn.jsdelivr.net/npm/mathjs@13.3.2/dist/math.min.js",
+    "https://cdnjs.cloudflare.com/ajax/libs/mathjs/11.11.2/math.min.js",
+    "https://cdnjs.cloudflare.com/ajax/libs/mathjs/11.3.0/math.min.js",
+    "https://cdnjs.cloudflare.com/ajax/libs/mathjs/11.3.2/math.min.js",
+    "https://cdnjs.cloudflare.com/ajax/libs/three.js/r132/three.min.js",
+    "https://cdnjs.cloudflare.com/ajax/libs/three.js/r153/three.min.js",
+    "https://cdn.jsdelivr.net/npm/three@0.153.0/examples/js/controls/OrbitControls.js",
+    "https://sagecell.sagemath.org/static/embedded_sagecell.js",
+    "https://cdnjs.cloudflare.com/ajax/libs/mathquill/0.10.1/mathquill.min.js"
+  ];
+  libs.forEach(url => {
+    const script = document.createElement('script');
+    script.src = url;
+    script.async = false;
+    document.head.appendChild(script);
+  });
+})();


### PR DESCRIPTION
## Summary
- bundle all CDN libraries into `common-libs.js`
- include the loader on every tool page

## Testing
- `npm test` *(fails: could not find package.json)*
- `make test` *(fails: no rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684f33f988708323b73cf05693454bb4